### PR TITLE
Fix Build Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:frontend": "cd frontend && pnpm run dev --host",
     "dev:backend": "cd backend && go run -tags dev . serve --dev=0",
     "build:frontend": "cd frontend && pnpm run generate",
-    "build:backend": "go build -ldflags=\"-s -w\" -C backend -o pocketvue .",
+    "build:backend": "go build -C backend -ldflags=\"-s -w\" -o pocketvue .",
     "generate:migrations": "cd backend && go run . migrate collections",
     "build": "pnpm run build:frontend && pnpm run build:backend",
     "typegen": "npx pocketbase-typegen --env --out frontend/types/pocketbase.ts",


### PR DESCRIPTION
The `pnpm build` command right now is failing with the following error:

```
> pocketvue@0.0.1 build:backend /Users/dan/Source/pocketvue
> go build -ldflags="-s -w" -C backend -o pocketvue .

invalid value "backend" for flag -C: -C flag must be first flag on command line
usage: go build [-o output] [build flags] [packages]
Run 'go help build' for details.
 ELIFECYCLE  Command failed with exit code 2.
 ELIFECYCLE  Command failed with exit code 2.
```


This PR fixes the `build:backend` script to have the correct order of command line arguments.