### PR TITLE
Add Coolify deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,53 @@
+# Node modules
+node_modules/
+frontend/node_modules/
+frontend/.nuxt/
+frontend/.output/
+
+# Build artifacts
+backend/pocketvue
+backend/ui/dist/
+builds/
+.builds/
+
+# Data directories
+backend/pb_data/
+pb_data/
+
+# Git
+.git/
+.github/
+.gitignore
+
+# IDE
+.vscode/
+.idea/
+
+# Environment files
+.env
+.env.*
+*.env
+backend/.env
+backend/.env.*
+frontend/.env
+frontend/.env.*
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Documentation
+*.md
+!README.md
+
+# Build scripts (not needed in container)
+build.sh
+.goreleaser.yaml
+
+# Lock files - we copy specific ones in Dockerfile
+# pnpm-lock.yaml is copied explicitly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# Stage 1: Build Frontend
+FROM node:20-alpine AS frontend-builder
+
+# Install pnpm
+RUN corepack enable pnpm
+
+WORKDIR /app
+
+# Copy package files for dependency installation
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY frontend/package.json ./frontend/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy frontend source
+COPY frontend ./frontend
+
+# Create backend/ui/dist directory (where Nuxt outputs)
+RUN mkdir -p backend/ui/dist
+
+# Build frontend (outputs to backend/ui/dist via nuxt.config.ts)
+RUN cd frontend && pnpm run generate
+
+# Stage 2: Build Backend
+FROM golang:1.24-alpine AS backend-builder
+
+WORKDIR /app
+
+# Copy backend source
+COPY backend ./backend
+
+# Copy generated frontend from previous stage
+COPY --from=frontend-builder /app/backend/ui/dist ./backend/ui/dist
+
+# Build the Go binary
+RUN cd backend && \
+    CGO_ENABLED=0 go build -ldflags="-s -w" -o pocketvue .
+
+# Stage 3: Runtime
+FROM alpine:latest
+
+# Install ca-certificates for HTTPS and timezone data
+RUN apk --no-cache add ca-certificates tzdata
+
+WORKDIR /app
+
+# Copy the binary from builder
+COPY --from=backend-builder /app/backend/pocketvue /app/pocketvue
+
+# Create pb_data directory for persistence
+RUN mkdir -p /app/pb_data
+
+# Expose PocketBase default port
+EXPOSE 8090
+
+# Volume for persistent data
+VOLUME ["/app/pb_data"]
+
+# Run the application
+# Note: In production, set FRONTEND_URL environment variable
+CMD ["/app/pocketvue", "serve", "--http=0.0.0.0:8090"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ All-in-one, single-binary SaaS starter kit that combines a PocketBase backend wi
 - [OAuth2 Providers](#oauth2-providers)
 - [Building for Production](#building-for-production)
 - [Deploying the Binary](#deploying-the-binary)
+  - [Deploying with Coolify](#deploying-with-coolify)
+  - [Deploying Pocketbase on DigitalOcean](#deploying-pocketbase-on-digitalocean)
 - [Useful Commands](#useful-commands)
 - [Contributing & Support](#contributing--support)
 
@@ -270,6 +272,45 @@ Deploy Pocketvue just like any PocketBase application:
    sudo systemctl enable pocketvue
    sudo systemctl start pocketvue
    ```
+
+### Deploying with Coolify
+
+[Coolify](https://coolify.io/) is an open-source platform for deploying applications. Pocketvue includes Docker support for easy deployment.
+
+#### Deployment Steps
+
+1. **Create New Application** in Coolify:
+   - Choose "Public Repository"
+   - Repository URL: `https://github.com/fayazara/pocketvue`
+   - Build Pack: `Dockerfile`
+   - Port Exposes: `8090`
+
+2. **Set Environment Variables**:
+   ```bash
+   FRONTEND_URL=https://your-domain.com
+   POLAR_ENVIRONMENT=production
+   POLAR_ACCESS_TOKEN=your_polar_access_token
+   POLAR_WEBHOOK_SECRET=your_polar_webhook_secret
+   ```
+
+3. **Configure Persistent Storage**:
+   - Add volume: Mount `/app/pb_data` (stores database and uploads)
+
+4. **Set Domain** and click **Deploy** (~3-5 minutes)
+
+#### Post-Deployment
+
+1. Visit `https://your-domain.com/_/` and create admin account
+2. Configure Application URL in Settings
+3. Set up SMTP in Mail settings
+4. (Optional) Configure OAuth providers with redirect URL: `https://your-domain.com/api/oauth2-redirect`
+5. Add Polar webhook: `https://your-domain.com/api/polar-webhook`
+
+#### Troubleshooting
+
+- Ensure Port Exposes is `8090` and volume is mounted at `/app/pb_data`
+- Verify `FRONTEND_URL` matches your domain
+- Check build logs in Coolify for errors
 
 ### Deploying Pocketbase on DigitalOcean
 


### PR DESCRIPTION
### Hola 

Implements #3

This PR adds native support for deploying Pocketvue on Coolify, making it easier for users to self-host without manual server configuration.

## Changes

- **Dockerfile** (62 lines): Multi-stage build for Nuxt frontend + Go backend
- **.dockerignore** (53 lines): Optimized build exclusions
- **README.md** (+42 lines): Concise Coolify deployment guide

## Testing

**Local testing:**
- ✅ Docker build succeeds
- ✅ Container runs on port 8090
- ✅ Application accessible and functional

**Live deployment:**
Deployed and tested on Coolify at https://pocketvue.boxgeist.com/

The deployment worked with minimal configuration - no `.env` file needed initially. Just two settings in Coolify were required to get it running:

[Screenshot - Coolify deployment configuration showing Dockerfile build pack and port 8090](https://github.com/user-attachments/assets/fa9501d0-a68b-4bb0-957e-caff70d50e56)

For data persistence, a volume mount was added:

[Screenshot - Coolify persistent storage configuration for /app/pb_data](https://github.com/user-attachments/assets/15b06b08-c621-4abb-932f-bb5c392a9649)


@fayazara Feel free to test the live deployment yourself! No superuser is created yet - you can set one up if you'd like to explore. I'll take this down in a few weeks.

## Implementation Notes

I went with a Dockerfile approach as it seemed like the simplest and most straightforward solution for this type of setup. It maintains the single-binary architecture while being compatible with container platforms.

That said, this is just a suggestion - if you prefer a different approach or don't think this fits the project, totally understandable!

Thanks for the work!

#### Cheers,
Frank :v: 